### PR TITLE
Updated imgui to exist in context

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,47 @@
+﻿---
+AlignConsecutiveAssignments: 'false'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortLambdasOnASingleLine: All
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: 'Yes'
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: BeforeComma
+ColumnLimit: '0'
+CompactNamespaces: 'false'
+Cpp11BracedListStyle: 'true'
+FixNamespaceComments: 'false'
+IncludeBlocks: Preserve
+IndentCaseLabels: 'false'
+IndentPPDirectives: None
+IndentWidth: '4'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'true'
+Language: Cpp
+MaxEmptyLinesToKeep: '4'
+NamespaceIndentation: All
+PointerAlignment: Left
+ReflowComments: 'false'
+SortIncludes: 'false'
+SortUsingDeclarations: 'true'
+SpaceAfterCStyleCast: 'false'
+SpaceAfterLogicalNot: 'false'
+SpaceAfterTemplateKeyword: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeCpp11BracedList: 'true'
+SpaceBeforeCtorInitializerColon: 'true'
+SpaceBeforeInheritanceColon: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: 'true'
+SpaceInEmptyParentheses: 'false'
+SpacesBeforeTrailingComments: '1'
+SpacesInAngles: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'true'
+SpacesInParentheses: 'true'
+SpacesInSquareBrackets: 'true'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: ForContinuationAndIndentation
+
+...

--- a/source/Engine/wv/Debug/Print.h
+++ b/source/Engine/wv/Debug/Print.h
@@ -42,7 +42,11 @@ namespace wv
 		#ifdef WV_PLATFORM_WINDOWS
 			static HANDLE hConsole = nullptr;
 
-			static std::mutex PRINT_MUTEX;
+			static std::mutex& getMutex()
+			{
+				static std::mutex PRINT_MUTEX{};
+				return PRINT_MUTEX;
+			}
 		#endif
 
 	///////////////////////////////////////////////////////////////////////////////////////
@@ -79,13 +83,13 @@ namespace wv
 		inline void Print( const char* _str, Args... _args )
 		{
 		#ifdef WV_PLATFORM_WINDOWS
-			Internal::PRINT_MUTEX.lock();
+			Internal::getMutex().lock();
 		#endif
 			printf( "%s", Internal::LEVEL_STR[ 0 ] );
 			printf( _str, _args... );
 
 		#ifdef WV_PLATFORM_WINDOWS
-			Internal::PRINT_MUTEX.unlock();
+			Internal::getMutex().unlock();
 		#endif
 		}
 
@@ -93,7 +97,7 @@ namespace wv
 		inline void Print( PrintLevel _printLevel, const char* _str, Args... _args )
 		{
 		#ifdef WV_PLATFORM_WINDOWS
-			Internal::PRINT_MUTEX.lock();
+			Internal::getMutex().lock();
 		#endif
 
 			
@@ -105,7 +109,7 @@ namespace wv
 			if( skip )
 			{
 			#ifdef WV_PLATFORM_WINDOWS
-				Internal::PRINT_MUTEX.unlock();
+				Internal::getMutex().unlock();
 			#endif
 				return;
 			}
@@ -124,7 +128,7 @@ namespace wv
 			printf( _str, _args... );
 
 		#ifdef WV_PLATFORM_WINDOWS
-			Internal::PRINT_MUTEX.unlock();
+			Internal::getMutex().unlock();
 		#endif
 		}
 	}

--- a/source/Engine/wv/Device/DeviceContext.cpp
+++ b/source/Engine/wv/Device/DeviceContext.cpp
@@ -24,7 +24,7 @@ wv::iDeviceContext* wv::iDeviceContext::getDeviceContext( ContextDesc* _desc )
 	case WV_DEVICE_CONTEXT_API_GLFW: context = new GLFWDeviceContext(); break;
 	#endif
 
-	#ifdef WV_SUPPORT_SDL
+	#ifdef WV_SUPPORT_SDL2
 	case WV_DEVICE_CONTEXT_API_SDL:  context = new SDLDeviceContext (); break;
 	#endif
 	}

--- a/source/Engine/wv/Device/DeviceContext.h
+++ b/source/Engine/wv/Device/DeviceContext.h
@@ -14,7 +14,7 @@ namespace wv
 	{
 		WV_DEVICE_CONTEXT_API_NONE
 
-	#ifdef WV_SUPPORT_SDL
+	#ifdef WV_SUPPORT_SDL2
 		,WV_DEVICE_CONTEXT_API_SDL
 	#endif
 
@@ -63,12 +63,14 @@ namespace wv
 
 		friend class iGraphicsDevice;
 
-		virtual ~iDeviceContext() { };
+		virtual ~iDeviceContext() { }
 
 		static iDeviceContext* getDeviceContext( ContextDesc* _desc );
 
-		virtual void initImGui() { Debug::Print( Debug::WV_PRINT_ERROR, "initImGui not implemented\n" ); };
-		virtual void terminateImGui() { };
+		virtual void initImGui() { Debug::Print( Debug::WV_PRINT_ERROR, "initImGui not implemented\n" ); }
+		virtual void terminateImGui() { }
+		virtual void newImGuiFrame() { Debug::Print( Debug::WV_PRINT_ERROR, "newImGuiFrame not implemented\n" ); }
+		virtual void renderImGui() { Debug::Print( Debug::WV_PRINT_ERROR, "renderImGui not implemented\n" ); }
 
 		virtual void terminate() = 0;
 		virtual GraphicsDriverLoadProc getLoadProc() = 0;

--- a/source/Engine/wv/Device/DeviceContext/GLFW/GLFWDeviceContext.cpp
+++ b/source/Engine/wv/Device/DeviceContext/GLFW/GLFWDeviceContext.cpp
@@ -13,6 +13,7 @@
 
 #ifdef WV_SUPPORT_IMGUI
 #include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -230,7 +231,10 @@ void wv::GLFWDeviceContext::initImGui()
 #ifdef WV_SUPPORT_IMGUI
 	switch ( m_graphicsApi )
 	{
-	case WV_GRAPHICS_API_OPENGL: case WV_GRAPHICS_API_OPENGL_ES1: case WV_GRAPHICS_API_OPENGL_ES2:
+	case WV_GRAPHICS_API_OPENGL:
+		ImGui_ImplOpenGL3_Init();
+	case WV_GRAPHICS_API_OPENGL_ES1:
+	case WV_GRAPHICS_API_OPENGL_ES2:
 		ImGui_ImplGlfw_InitForOpenGL( m_windowContext, true );
 		break;
 	}
@@ -242,7 +246,49 @@ void wv::GLFWDeviceContext::terminateImGui()
 {
 #ifdef WV_SUPPORT_GLFW
 #ifdef WV_SUPPORT_IMGUI
+	switch ( m_graphicsApi )
+	{
+	case WV_GRAPHICS_API_OPENGL:
+		ImGui_ImplOpenGL3_Shutdown();
+		break;
+	}
 	ImGui_ImplGlfw_Shutdown();
+#endif
+#endif
+}
+
+void wv::GLFWDeviceContext::newImGuiFrame()
+{
+#ifdef WV_SUPPORT_GLFW
+#ifdef WV_SUPPORT_IMGUI
+	switch ( m_graphicsApi )
+	{
+	case WV_GRAPHICS_API_OPENGL: case WV_GRAPHICS_API_OPENGL_ES1: case WV_GRAPHICS_API_OPENGL_ES2:
+		ImGui_ImplOpenGL3_NewFrame();
+		ImGui_ImplGlfw_NewFrame();
+		ImGui::NewFrame();
+		break;
+	default:
+		Debug::Print( Debug::WV_PRINT_FATAL, "GLFW context newImGuiFrame() graphics mode not supported" );
+	}
+#endif
+#endif
+}
+
+void wv::GLFWDeviceContext::renderImGui()
+{
+#ifdef WV_SUPPORT_GLFW
+#ifdef WV_SUPPORT_IMGUI
+	ImGui::Render();
+
+	switch ( m_graphicsApi )
+	{
+	case WV_GRAPHICS_API_OPENGL: case WV_GRAPHICS_API_OPENGL_ES1: case WV_GRAPHICS_API_OPENGL_ES2:
+		ImGui_ImplOpenGL3_RenderDrawData( ImGui::GetDrawData() );
+		break;
+	default:
+		Debug::Print( Debug::WV_PRINT_FATAL, "GLFW context renderImGui() graphics mode not supported" );
+	}
 #endif
 #endif
 }

--- a/source/Engine/wv/Device/DeviceContext/GLFW/GLFWDeviceContext.h
+++ b/source/Engine/wv/Device/DeviceContext/GLFW/GLFWDeviceContext.h
@@ -24,6 +24,8 @@ namespace wv
 
 		virtual void initImGui() override;
 		virtual void terminateImGui() override;
+		virtual void newImGuiFrame() override;
+		virtual void renderImGui() override;
 
 		GraphicsDriverLoadProc getLoadProc() override;
 

--- a/source/Engine/wv/Device/DeviceContext/SDL/SDLDeviceContext.h
+++ b/source/Engine/wv/Device/DeviceContext/SDL/SDLDeviceContext.h
@@ -25,6 +25,8 @@ namespace wv
 	public:
 		virtual void initImGui() override;
 		virtual void terminateImGui() override;
+		virtual void newImGuiFrame() override;
+		virtual void renderImGui() override;
 
 		void terminate() override;
 

--- a/source/Engine/wv/Misc/Time.cpp
+++ b/source/Engine/wv/Misc/Time.cpp
@@ -1,0 +1,25 @@
+#include "Time.h"
+
+#ifdef WV_PLATFORM_WINDOWS
+#include <chrono>
+#endif
+
+#include <thread>
+
+///////////////////////////////////////////////////////////////////////////////////////
+
+void wv::time::sleepForSeconds( double _seconds )
+{
+#ifdef WV_PLATFORM_WINDOWS
+	std::chrono::milliseconds time( static_cast<std::chrono::milliseconds::rep>( _seconds * 1000 ) );
+	std::this_thread::sleep_for( time );
+#elif WV_PLATFORM_PSVITA
+	xtime t;
+	t.sec = _seconds;
+	_Thrd_sleep( &t );
+#else
+#error sleep_for not implemented on this platform
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////////////////////

--- a/source/Engine/wv/Misc/Time.h
+++ b/source/Engine/wv/Misc/Time.h
@@ -1,0 +1,15 @@
+#pragma once
+
+///////////////////////////////////////////////////////////////////////////////////////
+
+namespace wv
+{
+
+	namespace time
+	{
+		/// Sleep for the given duration of seconds
+		/// 
+		/// @param _seconds the amount of seconds to sleep
+		void sleepForSeconds ( double _seconds );
+	}
+}

--- a/source/Engine/wv/Resource/cResourceLoader.cpp
+++ b/source/Engine/wv/Resource/cResourceLoader.cpp
@@ -4,7 +4,7 @@
 #include <wv/Memory/FileSystem.h>
 #include <wv/Device/GraphicsDevice.h>
 
-#include <chrono>
+#include <wv/Misc/Time.h>
 
 void threadedLoad( wv::cFileSystem* _pFileSystem, wv::iGraphicsDevice* _pGraphicsDevice, wv::sLoaderInformation* _loaderInfo, wv::sLoadWorker* _worker )
 {
@@ -29,16 +29,11 @@ void threadedLoad( wv::cFileSystem* _pFileSystem, wv::iGraphicsDevice* _pGraphic
 		{
 
 		case wv::WV_WORKER_IDLE:
-			
-			/// TODO: wv::time
-		#ifdef WV_PLATFORM_WINDOWS
-			std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) ); break;
-		#elif WV_PLATFORM_PSVITA
-			xtime t;
-			t.sec = 0.1;
-			_Thrd_sleep( &t );
-		#endif
-		
+		{
+			wv::time::sleepForSeconds( 0.1 );
+			break;
+		}
+
 		case wv::WV_WORKER_WORKING:
 		{
 			currentlyLoading->load( _pFileSystem, _pGraphicsDevice );


### PR DESCRIPTION
* ImGui specific GLFW / SDL / OpenGL methods are now in context and not in cEngine
* Time class introduced for thread sleep
* SDL window updated to fix mouse relative motion?
* Print class now loads mutex in a non crash way
* Added clang format file